### PR TITLE
Update udev-worker.c

### DIFF
--- a/src/udev/udev-worker.c
+++ b/src/udev/udev-worker.c
@@ -248,7 +248,7 @@ void udev_broadcast_result(sd_device_monitor *monitor, sd_device *dev, EventResu
                                 (void) device_add_property(dev, "UDEV_WORKER_ERRNO_NAME", str);
                         break;
                 }
-                case EVENT_RESULT_EXIT_STATUS_BASE ... EVENT_RESULT_EXIT_STATUS_MAX:
+                case EVENT_RESULT_EXIT_STATUS_BASE_START ... EVENT_RESULT_EXIT_STATUS_MAX:
                         (void) device_add_propertyf(dev, "UDEV_WORKER_EXIT_STATUS", "%i", result - EVENT_RESULT_EXIT_STATUS_BASE);
                         break;
 


### PR DESCRIPTION
There is no need for the EVENT_RESULT_EXIT_STATUS_BASE as the result value will never be 0 because of this condition: if (result != EVENT_RESULT_SUCCESS). Both EVENT_RESULT_EXIT_STATUS_BASE and EVENT_RESULT_SUCCESS have the value 0. So added an EVENT_RESULT_EXIT_STATUS_BASE_START with value 1 in the enum